### PR TITLE
feat(login機能): ログイン機能を実装した

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/jp/co/meal_management/config/SecurityConfig.java
+++ b/src/main/java/jp/co/meal_management/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package jp.co.meal_management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/login").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                //.loginPage("/login")
+                .defaultSuccessUrl("/top", true)
+                .failureUrl("/login?error=true")
+            )
+            .logout(logout -> logout
+                .logoutSuccessUrl("/login?logout=true")
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/jp/co/meal_management/domain/entity/UserAuths.java
+++ b/src/main/java/jp/co/meal_management/domain/entity/UserAuths.java
@@ -1,0 +1,126 @@
+package jp.co.meal_management.domain.entity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Data;
+
+@Entity
+@Table(name = "user_auths", indexes = {
+		@Index(name = "idx_user_id", columnList = "user_id")
+}, uniqueConstraints = {
+		@UniqueConstraint(name = "uk_email", columnNames = { "email" })
+})
+@Data
+public class UserAuths implements UserDetails {
+
+	/* フィールドの定義 */
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "user_id", updatable = false, nullable = false)
+	private UUID userId;
+
+	@Column(name = "email", unique = true)
+	private String email;
+
+	@Column(name = "password_hash", unique = true)
+	private String passwordHash;
+
+	@Column(name = "authorities")
+	private String authorities;
+
+	@Column(name = "account_non_expired")
+	private boolean accountNonExpired;
+
+	@Column(name = "account_non_locked")
+	private boolean accountNonLocked;
+
+	@Column(name = "credentials_non_expired")
+	private boolean credentialsNonExpired;
+
+	@Column(name = "enabled")
+	private boolean enabled;
+
+	@Column(name = "failed_attempt")
+	private int failedAttempt;
+
+	@Column(name = "lock_time")
+	private LocalDateTime lockTime;
+
+	@Column(name = "last_login")
+	private LocalDateTime lastLogin;
+
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	/* メソッドの定義 */
+
+	// Userの権限を返すメソッド
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Arrays.stream(authorities.split(","))
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+	}
+
+	// ハッシュ化したパスワードのセッター
+	public void setPasswordHash(String passwordHash) {
+		this.passwordHash = passwordHash;
+	}
+
+	// パスワードのゲッター
+	@Override
+	public String getPassword() {
+		return this.passwordHash;
+	}
+
+	// ユーザー名のゲッター
+	@Override
+	public String getUsername() {
+		return this.email;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return this.accountNonExpired;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return this.accountNonLocked;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return this.credentialsNonExpired;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+}

--- a/src/main/java/jp/co/meal_management/domain/entity/UserInfos.java
+++ b/src/main/java/jp/co/meal_management/domain/entity/UserInfos.java
@@ -1,24 +1,31 @@
 package jp.co.meal_management.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
-import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.util.Date;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
 
 @Entity
+@Table(name = "user_infos", indexes = {
+		@Index(name = "idx_user_id", columnList = "user_id")
+})
 @Data
 public class UserInfos {
 
 	@Id
 	@Column(name = "user_id")
-	private int userId;
+	private UUID userId;
 
 	@Column(name = "user_name")
 	private String userName;
@@ -27,7 +34,7 @@ public class UserInfos {
 	private String userNameKna;
 
 	@Column(name = "birthday")
-	private Date birthday;
+	private LocalDateTime birthday;
 
 	@Column(name = "age")
 	private int age;
@@ -42,13 +49,16 @@ public class UserInfos {
 	private int bodyMakeSettingId;
 
 	@CreationTimestamp
-	@Temporal(TemporalType.TIMESTAMP)
 	@Column(name = "created_at", nullable = false, updatable = false)
-	private Date createdAt;
+	private LocalDateTime createdAt;
 
 	@UpdateTimestamp
-	@Temporal(TemporalType.TIMESTAMP)
 	@Column(name = "updated_at", nullable = false)
-	private Date updatedAt;
+	private LocalDateTime updatedAt;
+
+	@OneToOne
+	@MapsId
+	@JoinColumn(name = "user_id")
+	private UserAuths userAuths;
 
 }

--- a/src/main/java/jp/co/meal_management/domain/repository/UserAuthRepository.java
+++ b/src/main/java/jp/co/meal_management/domain/repository/UserAuthRepository.java
@@ -1,0 +1,17 @@
+package jp.co.meal_management.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import jp.co.meal_management.domain.entity.UserAuths;
+
+/**
+ * @author sho.okazaki
+ * 
+ */
+public interface UserAuthRepository extends JpaRepository<UserAuths, UUID> {
+	Optional<UserAuths> findByEmail(String email);
+
+}

--- a/src/main/java/jp/co/meal_management/domain/repository/UserInfoRepository.java
+++ b/src/main/java/jp/co/meal_management/domain/repository/UserInfoRepository.java
@@ -1,7 +1,6 @@
-/**
- * 
- */
 package jp.co.meal_management.domain.repository;
+
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,6 +10,6 @@ import jp.co.meal_management.domain.entity.UserInfos;
  * @author sho.okazaki
  *
  */
-public interface UserInfoRepository extends JpaRepository<UserInfos, Integer> {
+public interface UserInfoRepository extends JpaRepository<UserInfos, UUID> {
 
 }

--- a/src/main/java/jp/co/meal_management/domain/service/UserDetailsServiceImpl.java
+++ b/src/main/java/jp/co/meal_management/domain/service/UserDetailsServiceImpl.java
@@ -1,0 +1,23 @@
+package jp.co.meal_management.domain.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import jp.co.meal_management.domain.entity.UserAuths;
+import jp.co.meal_management.domain.repository.UserAuthRepository;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	@Autowired
+	UserAuthRepository userAuthRepository;
+
+	@Override
+	public UserAuths loadUserByUsername(String email) throws UsernameNotFoundException {
+		return userAuthRepository.findByEmail(email)
+				.orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 spring.application.name=MealManagement
+
+# データベース接続の設定
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://localhost:5432/meal_management
 spring.datasource.username=postgres
@@ -7,3 +9,14 @@ spring.jpa.open-in-view=false
 
 # 外部propertiesファイルの読込
 spring.config.import=classpath:Constant.properties
+
+# Thymleafの設定
+spring.thymeleaf.prefix=classpath:/templates/
+spring.thymeleaf.suffix=.html
+spring.thymeleaf.mode=HTML
+
+# コンテキストパスの設定
+server.servlet.context-path=/MealManagement
+
+# logの設定
+logging.level.org.springframework.security=DEBUG

--- a/src/test/java/jp/co/meal_management/PasswordEncoderExample.java
+++ b/src/test/java/jp/co/meal_management/PasswordEncoderExample.java
@@ -1,0 +1,12 @@
+package jp.co.meal_management;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class PasswordEncoderExample {
+    public static void main(String[] args) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        String rawPassword = "test1234";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+        System.out.println("Encoded password: " + encodedPassword);
+    }
+}


### PR DESCRIPTION
#### 実装機能の簡単な説明
今回の実装に伴い、user_authsテーブル、user_infosテーブルも作成した。
SpringSecurityの下記の基本的な機能でログイン機能を実装した。
- メールアドレスとパスワードでログインするフォームログイン機能
- 権限は特に設けていない
- `BCryptPasswordEncoder`を用いたパスワードのハッシュ化

#### できること
- 既存会員のログイン
- 既存会員は手動でパスワードをハッシュ化してテーブルに登録する
- 成功したらTOP画面へ遷移、失敗したらログインエラー画面へ遷移
