### PR TITLE
Issue#9：体重の記録に必要なログイン情報をセッションから取得

### DIFF
--- a/src/main/java/jp/co/meal_management/config/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/jp/co/meal_management/config/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,55 @@
+package jp.co.meal_management.config;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jp.co.meal_management.domain.entity.UserAuths;
+import jp.co.meal_management.domain.entity.UserInfos;
+import jp.co.meal_management.domain.repository.UserInfoRepository;
+
+@Component
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+	// private static final Logger logger = LoggerFactory.getLogger(CustomAuthenticationSuccessHandler.class);
+
+	@Autowired
+	private UserInfoRepository userInfoRepository;
+
+	/**
+	 * ログイン成功時にSessionにUserInfosを保存するためのメソッドです。
+	 * @throws ServletException 
+	 */
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+			Authentication authentication) throws IOException, ServletException {
+
+		try {
+			// authenticationからUserIdを取得する
+			UserAuths userAuths = (UserAuths) authentication.getPrincipal();
+			UUID userId = userAuths.getUserId();
+
+			// 取得したUserIdからUserInfosのレコードを検索する
+			UserInfos userInfo = userInfoRepository.findById(userId)
+					.orElseThrow(() -> new RuntimeException("User not found for ID: " + userId));
+
+			// SessionにuserInfosを保存する
+			HttpSession session = request.getSession();
+			session.setAttribute("USER_INFO", userInfo);
+
+			response.sendRedirect(request.getContextPath() + "/top");
+		} catch (Exception e) {
+			
+			throw new ServletException("Unexpected error occurred during authentication success handling", e);
+		}
+	}
+
+}

--- a/src/main/java/jp/co/meal_management/config/SecurityConfig.java
+++ b/src/main/java/jp/co/meal_management/config/SecurityConfig.java
@@ -24,7 +24,6 @@ public class SecurityConfig {
 						.anyRequest().authenticated())
 				.formLogin(form -> form
 						// .loginPage("/login")
-						//.defaultSuccessUrl("/top", true)
 						.successHandler(customAuthenticationSuccessHandler)
 						.failureUrl("/login?error=true"))
 				.logout(logout -> logout

--- a/src/main/java/jp/co/meal_management/config/SecurityConfig.java
+++ b/src/main/java/jp/co/meal_management/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package jp.co.meal_management.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,27 +13,28 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-            .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/login").permitAll()
-                .anyRequest().authenticated()
-            )
-            .formLogin(form -> form
-                //.loginPage("/login")
-                .defaultSuccessUrl("/top", true)
-                .failureUrl("/login?error=true")
-            )
-            .logout(logout -> logout
-                .logoutSuccessUrl("/login?logout=true")
-            );
+	@Autowired
+	private CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
 
-        return http.build();
-    }
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+				.authorizeHttpRequests(authz -> authz
+						.requestMatchers("/login").permitAll()
+						.anyRequest().authenticated())
+				.formLogin(form -> form
+						// .loginPage("/login")
+						//.defaultSuccessUrl("/top", true)
+						.successHandler(customAuthenticationSuccessHandler)
+						.failureUrl("/login?error=true"))
+				.logout(logout -> logout
+						.logoutSuccessUrl("/login?logout=true"));
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 }

--- a/src/main/java/jp/co/meal_management/controller/MealManagementController.java
+++ b/src/main/java/jp/co/meal_management/controller/MealManagementController.java
@@ -61,6 +61,7 @@ public class MealManagementController {
 	public String postWeightRecord(@ModelAttribute BodyMetrics bodyMetrics, Model model) {
 		try {
 			mealManagementRecord.saveWeightEntity(sessionUserProvider.getCurrentUser(), bodyMetrics.getWeightKg());
+			mealManagementRecord.saveMarEntity(sessionUserProvider.getCurrentUser(), bodyMetrics.getWeightKg());
 			return "mealManagementWeightRecord";
 
 		} catch (RuntimeException e) {

--- a/src/main/java/jp/co/meal_management/controller/MealManagementController.java
+++ b/src/main/java/jp/co/meal_management/controller/MealManagementController.java
@@ -47,7 +47,7 @@ public class MealManagementController {
 	}
 
 	@GetMapping("/weight-record")
-	public String showWeightRecord(Model model) {
+	public String getWeightRecord(Model model) {
 		model.addAttribute("bodyMetrics", new BodyMetrics());
 		return "mealManagementWeightRecord";
 

--- a/src/main/java/jp/co/meal_management/controller/MealManagementController.java
+++ b/src/main/java/jp/co/meal_management/controller/MealManagementController.java
@@ -1,5 +1,7 @@
 package jp.co.meal_management.controller;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import jp.co.meal_management.domain.entity.BodyMetrics;
+import jp.co.meal_management.infrastructure.security.SessionUserProvider;
 import jp.co.meal_management.use_case.MealManagementRecord;
 
 @Controller
@@ -15,6 +18,9 @@ public class MealManagementController {
 
 	@Autowired
 	private MealManagementRecord mealManagementRecord;
+	
+	@Autowired
+	private SessionUserProvider sessionUserProvider;
 
 	@GetMapping("/top")
 	public String showMealManagementTop(Model model) {
@@ -55,9 +61,14 @@ public class MealManagementController {
 
 	@PostMapping("/weight-record")
 	public String postWeightRecord(@ModelAttribute BodyMetrics bodyMetrics) {
-
-		mealManagementRecord.saveWeightEntity(bodyMetrics.getWeightKg());
-		return "mealManagementWeightRecord";
+		try {
+			UUID userId = sessionUserProvider.getCurrentUserId();
+			mealManagementRecord.saveWeightEntity(userId,bodyMetrics.getWeightKg());
+			return "mealManagementWeightRecord";
+			
+		}catch (RuntimeException e) {
+			return "mealManagementTop";
+		}
 
 	}
 

--- a/src/main/java/jp/co/meal_management/controller/MealManagementController.java
+++ b/src/main/java/jp/co/meal_management/controller/MealManagementController.java
@@ -1,7 +1,5 @@
 package jp.co.meal_management.controller;
 
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -18,7 +16,7 @@ public class MealManagementController {
 
 	@Autowired
 	private MealManagementRecord mealManagementRecord;
-	
+
 	@Autowired
 	private SessionUserProvider sessionUserProvider;
 
@@ -60,16 +58,14 @@ public class MealManagementController {
 	}
 
 	@PostMapping("/weight-record")
-	public String postWeightRecord(@ModelAttribute BodyMetrics bodyMetrics) {
+	public String postWeightRecord(@ModelAttribute BodyMetrics bodyMetrics, Model model) {
 		try {
-			UUID userId = sessionUserProvider.getCurrentUserId();
-			mealManagementRecord.saveWeightEntity(userId,bodyMetrics.getWeightKg());
+			mealManagementRecord.saveWeightEntity(sessionUserProvider.getCurrentUser(), bodyMetrics.getWeightKg());
 			return "mealManagementWeightRecord";
-			
-		}catch (RuntimeException e) {
-			return "mealManagementTop";
+
+		} catch (RuntimeException e) {
+			model.addAttribute("error", "体重の記録に失敗しました。");
+			return "mealManagementWeightRecord";
 		}
-
 	}
-
 }

--- a/src/main/java/jp/co/meal_management/domain/entity/BodyMetrics.java
+++ b/src/main/java/jp/co/meal_management/domain/entity/BodyMetrics.java
@@ -1,17 +1,18 @@
 package jp.co.meal_management.domain.entity;
 
+import java.util.Date;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-
 import lombok.Data;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.util.Date;
 
 @Entity
 @IdClass(BodyMetricsId.class)
@@ -20,7 +21,7 @@ public class BodyMetrics {
 
 	@Id
 	@Column(name = "user_id")
-	private int userId;
+	private UUID userId;
 
 	@Id
 	@Column(name = "record_date")

--- a/src/main/java/jp/co/meal_management/domain/entity/BodyMetricsId.java
+++ b/src/main/java/jp/co/meal_management/domain/entity/BodyMetricsId.java
@@ -1,18 +1,18 @@
 package jp.co.meal_management.domain.entity;
 
 import java.io.Serializable;
-
 import java.util.Date;
 import java.util.Objects;
+import java.util.UUID;
 
 public class BodyMetricsId implements Serializable {
-	private int userId;
+	private UUID userId;
 	private Date recordDate;
 
 	public BodyMetricsId() {
 	}
 
-	public BodyMetricsId(int userId, Date recordDate) {
+	public BodyMetricsId(UUID userId, Date recordDate) {
 		this.userId = userId;
 		this.recordDate = recordDate;
 	}

--- a/src/main/java/jp/co/meal_management/domain/entity/UserInfos.java
+++ b/src/main/java/jp/co/meal_management/domain/entity/UserInfos.java
@@ -1,5 +1,6 @@
 package jp.co.meal_management.domain.entity;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -21,7 +22,7 @@ import lombok.Data;
 		@Index(name = "idx_user_id", columnList = "user_id")
 })
 @Data
-public class UserInfos {
+public class UserInfos implements Serializable{
 
 	@Id
 	@Column(name = "user_id")

--- a/src/main/java/jp/co/meal_management/domain/service/BodyMetricsService.java
+++ b/src/main/java/jp/co/meal_management/domain/service/BodyMetricsService.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public interface BodyMetricsService {
 
-	public double calcurateMar(int age, int sex, double weightKg, double heightCm);
+	public double calculateMar(int age, int sex, double weightKg, double heightCm);
 
 }

--- a/src/main/java/jp/co/meal_management/domain/service/BodyMetricsService.java
+++ b/src/main/java/jp/co/meal_management/domain/service/BodyMetricsService.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public interface BodyMetricsService {
 
-	public double calcurateMar(int sex, double weightKg, double heightCm, int age);
+	public double calcurateMar(int age, int sex, double weightKg, double heightCm);
 
 }

--- a/src/main/java/jp/co/meal_management/domain/service/BodyMetricsServiceImpl.java
+++ b/src/main/java/jp/co/meal_management/domain/service/BodyMetricsServiceImpl.java
@@ -23,7 +23,7 @@ public class BodyMetricsServiceImpl implements BodyMetricsService {
 	 * @return MAR
 	 */
 	@Override
-	public double calcurateMar(int sex, double weightKg, double heightCm, int age) {
+	public double calcurateMar(int age, int sex, double weightKg, double heightCm) {
 		if (bodyMetricsConstant.getMen() == sex) {
 			return bodyMetricsConstant.getMenWeightKgConst() * weightKg
 					+ bodyMetricsConstant.getMenHeightCmConst() * heightCm

--- a/src/main/java/jp/co/meal_management/domain/service/BodyMetricsServiceImpl.java
+++ b/src/main/java/jp/co/meal_management/domain/service/BodyMetricsServiceImpl.java
@@ -23,7 +23,7 @@ public class BodyMetricsServiceImpl implements BodyMetricsService {
 	 * @return MAR
 	 */
 	@Override
-	public double calcurateMar(int age, int sex, double weightKg, double heightCm) {
+	public double calculateMar(int age, int sex, double weightKg, double heightCm) {
 		if (bodyMetricsConstant.getMen() == sex) {
 			return bodyMetricsConstant.getMenWeightKgConst() * weightKg
 					+ bodyMetricsConstant.getMenHeightCmConst() * heightCm

--- a/src/main/java/jp/co/meal_management/infrastructure/security/SessionUserProvider.java
+++ b/src/main/java/jp/co/meal_management/infrastructure/security/SessionUserProvider.java
@@ -1,0 +1,31 @@
+package jp.co.meal_management.infrastructure.security;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpSession;
+import jp.co.meal_management.domain.entity.UserInfos;
+
+@Component
+public class SessionUserProvider {
+
+	public UserInfos getCurrentUser() {
+		ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+		HttpSession session = attr.getRequest().getSession(true);
+		UserInfos user = (UserInfos) session.getAttribute("USER_INFO");
+
+		if (user == null) {
+			throw new RuntimeException("User not found in session");
+		}
+
+		return user;
+	}
+
+	public UUID getCurrentUserId() {
+		return getCurrentUser().getUserId();
+	}
+
+}

--- a/src/main/java/jp/co/meal_management/infrastructure/security/SessionUserProvider.java
+++ b/src/main/java/jp/co/meal_management/infrastructure/security/SessionUserProvider.java
@@ -1,6 +1,6 @@
 package jp.co.meal_management.infrastructure.security;
 
-import java.util.UUID;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -8,11 +8,18 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import jakarta.servlet.http.HttpSession;
 import jp.co.meal_management.domain.entity.UserInfos;
+import jp.co.meal_management.domain.repository.UserInfoRepository;
 
 @Component
 public class SessionUserProvider {
 
-	public UserInfos getCurrentUser() {
+	private final UserInfoRepository userInfoRepository;
+
+	public SessionUserProvider(UserInfoRepository userInfoRepository) {
+		this.userInfoRepository = userInfoRepository;
+	}
+
+	public Optional<UserInfos> getCurrentUser() {
 		ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
 		HttpSession session = attr.getRequest().getSession(true);
 		UserInfos user = (UserInfos) session.getAttribute("USER_INFO");
@@ -21,11 +28,7 @@ public class SessionUserProvider {
 			throw new RuntimeException("User not found in session");
 		}
 
-		return user;
-	}
-
-	public UUID getCurrentUserId() {
-		return getCurrentUser().getUserId();
+		return userInfoRepository.findById(user.getUserId());
 	}
 
 }

--- a/src/main/java/jp/co/meal_management/use_case/BodyMetricsRecordImpl.java
+++ b/src/main/java/jp/co/meal_management/use_case/BodyMetricsRecordImpl.java
@@ -1,11 +1,13 @@
 package jp.co.meal_management.use_case;
 
 import java.util.Date;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
 import jp.co.meal_management.domain.entity.BodyMetrics;
 import jp.co.meal_management.domain.entity.BodyMetricsId;
+import jp.co.meal_management.domain.entity.UserInfos;
 import jp.co.meal_management.domain.repository.BodyMetricsRepository;
 import jp.co.meal_management.domain.repository.CustomRepository;
 import jp.co.meal_management.domain.service.BodyMetricsService;
@@ -24,9 +26,8 @@ public class BodyMetricsRecordImpl implements MealManagementRecord {
 	private final BodyMetricsService bodyMetricsService;
 
 	public BodyMetricsRecordImpl(
-			CustomRepository customRepository
-			, BodyMetricsRepository bodyMetricsRepository
-			, BodyMetricsService bodyMetricsService) {
+			CustomRepository customRepository, BodyMetricsRepository bodyMetricsRepository,
+			BodyMetricsService bodyMetricsService) {
 		this.customRepository = customRepository;
 		this.bodyMetricsRepository = bodyMetricsRepository;
 		this.bodyMetricsService = bodyMetricsService;
@@ -40,22 +41,38 @@ public class BodyMetricsRecordImpl implements MealManagementRecord {
 	 */
 	@Override
 	public void saveWeightEntity(double weightKg) {
+		// UserInfoのインスタンスを生成
+		UserInfos userInfos = new UserInfos();
+		// BodyMetricsのインスタンスを生成
 		BodyMetrics bodyMetrics = new BodyMetrics();
+		
+		// ここは本当はSessionIdからUserIdを引き当てたい。
+		userInfos.setUserId(UUID.fromString("c8c5ddf0-2f64-4fdb-ab6b-2b31fc9d6247"));
 
 		// user_idを設定
-		bodyMetrics.setUserId(005);
+		bodyMetrics.setUserId(userInfos.getUserId());
+
 		// 今日の日付を設定
 		bodyMetrics.setRecordDate(new Date());
+
 		// BodyMetricsIdのuserIdに値を設定
 		BodyMetricsId bodyMetricsId = new BodyMetricsId(bodyMetrics.getUserId(), bodyMetrics.getRecordDate());
 
 		// 体重を更新
 		customRepository.upsert(bodyMetricsRepository, bodyMetrics, bodyMetricsId, "weightKg", weightKg);
-		
+
 		// 基礎代謝を計算
 		double mar = bodyMetricsService.calcurateMar(1, weightKg, 172.6, 25);
+
 		// 基礎代謝を更新
 		customRepository.upsert(bodyMetricsRepository, bodyMetrics, bodyMetricsId, "mar", mar);
+	}
+	
+	@Override
+	public void saveTeaEntity(double tea) {
+		
+		// BodyMetricsのインスタンスを生成
+		BodyMetrics bodyMetrics = new BodyMetrics();
 	}
 
 }

--- a/src/main/java/jp/co/meal_management/use_case/BodyMetricsRecordImpl.java
+++ b/src/main/java/jp/co/meal_management/use_case/BodyMetricsRecordImpl.java
@@ -37,42 +37,50 @@ public class BodyMetricsRecordImpl implements MealManagementRecord {
 		this.userInfoRepository = userInfoRepository;
 	}
 
-	// インスタンス変数としてuserIdとrecordDateを取得しておきたい
-
 	/**
 	 * 体重の値を受取ってテーブルを更新するメソッドです。 <br>
 	 * 体重を更新すると同時に基礎代謝も更新します。
 	 */
 	@Override
-	public void saveWeightEntity(UUID userId, double weightKg) {
-		// 会員情報の取得
-		Optional<UserInfos> foundEntity = userInfoRepository.findById(userId);
-		int age = foundEntity.get().getAge(); 
-		int sexId = foundEntity.get().getSexId();
-		double heightCm = foundEntity.get().getHeightCm();
-		
-		
+	public void saveWeightEntity(Optional<UserInfos> foundEntity, double weightKg) {
+		// ローカル変数の宣言
+		UUID userId_ = foundEntity.get().getUserId();
+		int age_ = foundEntity.get().getAge();
+		int sexId_ = foundEntity.get().getSexId();
+		double heightCm_ = foundEntity.get().getHeightCm();
+
 		// BodyMetricsのインスタンスを生成
 		BodyMetrics bodyMetrics = new BodyMetrics();
 
 		// BodyMetricsIdの生成
-		BodyMetricsId bodyMetricsId = new BodyMetricsId(foundEntity.get().getUserId(), new Date());
+		BodyMetricsId bodyMetricsId = new BodyMetricsId(userId_, new Date());
 
 		// 基礎代謝を計算
-		double mar = bodyMetricsService.calcurateMar(age, sexId, weightKg, heightCm);
+		double mar_ = bodyMetricsService.calcurateMar(age_, sexId_, weightKg, heightCm_);
 
 		// 体重を更新
 		customRepository.upsert(bodyMetricsRepository, bodyMetrics, bodyMetricsId, "weightKg", weightKg);
 
 		// 基礎代謝を更新
-		customRepository.upsert(bodyMetricsRepository, bodyMetrics, bodyMetricsId, "mar", mar);
+		customRepository.upsert(bodyMetricsRepository, bodyMetrics, bodyMetricsId, "mar", mar_);
 	}
 
+	/**
+	 * 運動消費カロリーの値を受取ってテーブルを更新するメソッドです。 <br>
+	 */
 	@Override
-	public void saveTeaEntity(UUID userId, double tea) {
+	public void saveTeaEntity(Optional<UserInfos> foundEntity, double tea) {
+		// ローカル変数の宣言
+		UUID userId_ = foundEntity.get().getUserId();
 
 		// BodyMetricsのインスタンスを生成
 		BodyMetrics bodyMetrics = new BodyMetrics();
+
+		// BodyMetricsIdの生成
+		BodyMetricsId bodyMetricsId = new BodyMetricsId(userId_, new Date());
+
+		// 運動消費カロリーを更新
+		customRepository.upsert(bodyMetricsRepository, bodyMetrics, bodyMetricsId, "tea", tea);
 	}
 
 }

--- a/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
+++ b/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
@@ -1,7 +1,9 @@
 package jp.co.meal_management.use_case;
 
+import java.util.UUID;
+
 public interface MealManagementRecord {
 	
-	public void saveWeightEntity(double weightKg);
-	public void saveTeaEntity(double tea);
+	public void saveWeightEntity(UUID userId, double weightKg);
+	public void saveTeaEntity(UUID userId, double tea);
 }

--- a/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
+++ b/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
@@ -1,5 +1,7 @@
 package jp.co.meal_management.use_case;
 
 public interface MealManagementRecord {
+	
 	public void saveWeightEntity(double weightKg);
+	public void saveTeaEntity(double tea);
 }

--- a/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
+++ b/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
@@ -1,9 +1,11 @@
 package jp.co.meal_management.use_case;
 
-import java.util.UUID;
+import java.util.Optional;
+
+import jp.co.meal_management.domain.entity.UserInfos;
 
 public interface MealManagementRecord {
 	
-	public void saveWeightEntity(UUID userId, double weightKg);
-	public void saveTeaEntity(UUID userId, double tea);
+	public void saveWeightEntity(Optional<UserInfos> foundEntity, double weightKg);
+	public void saveTeaEntity(Optional<UserInfos> foundEntity, double tea);
 }

--- a/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
+++ b/src/main/java/jp/co/meal_management/use_case/MealManagementRecord.java
@@ -7,5 +7,6 @@ import jp.co.meal_management.domain.entity.UserInfos;
 public interface MealManagementRecord {
 	
 	public void saveWeightEntity(Optional<UserInfos> foundEntity, double weightKg);
+	public void saveMarEntity(Optional<UserInfos> foundEntity, double weightKg);
 	public void saveTeaEntity(Optional<UserInfos> foundEntity, double tea);
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,5 @@
+{"properties": [{
+  "name": "Copyserver.servlet.session.timeout",
+  "type": "java.lang.String",
+  "description": "A description for 'Copyserver.servlet.session.timeout'"
+}]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ server.servlet.context-path=/MealManagement
 
 # logの設定
 logging.level.org.springframework.security=DEBUG
+
+# セッションの設定
+Copyserver.servlet.session.timeout=30m


### PR DESCRIPTION
## 概要
ログインしたユーザー情報毎に体重を保存できるようにしたかったため

## 変更点
- ログインが成功したら、sessionにUserInfosを保存する処理を追加
- SecurityConfigで設定するTOP画面へのリダイレクトのメソッドはsuccessHandlerというカスタムメソッドを使用するように変更
- SessionからUserInfosを取得し、BodyMetricsエンティティクラスを生成し体重や基礎代謝などをテーブルに保存する処理を追加

## 関連Issue
https://github.com/SHOzakioka/MealManagementForTrainee/issues/9

## 動作確認
- アプリケーションを実行しテストユーザーでログインする
- 対象の画面に遷移し、体重の数値を入れてテーブルに保存できることを確認した

## その他